### PR TITLE
Drop apostrophe in benchlib.pl

### DIFF
--- a/benchlib.pl
+++ b/benchlib.pl
@@ -80,7 +80,7 @@ BEGIN {
 EOT
     }
 
-    print $code if $main'debug;
+    print $code if $main::debug;
     eval $code;
     if ($@) {
         die $@;


### PR DESCRIPTION
Fixing the `Old package separator "'" deprecated at benchlib.pl line 83.`